### PR TITLE
Compilations errors on C++11

### DIFF
--- a/DS1307.cpp
+++ b/DS1307.cpp
@@ -1,6 +1,7 @@
 /*
   DS1307.cpp - Arduino library support for the DS1307 I2C Real-Time Clock
   Copyright (C)2015 Rinky-Dink Electronics, Henning Karlsen. All right reserved
+  Copyright (C)2018 Spacial. All right reserved
   
   This library has been made to easily interface and use the DS1307 RTC with
   the Arduino without needing the Wire library.

--- a/DS1307.cpp
+++ b/DS1307.cpp
@@ -99,7 +99,7 @@ void DS1307::setDOW(uint8_t dow)
 
 char *DS1307::getTimeStr(uint8_t format)
 {
-	char *output= "xxxxxxxx";
+	char *output= (char*)"xxxxxxxx";
 	Time t;
 	t=getTime();
 	if (t.hour<10)
@@ -130,7 +130,7 @@ char *DS1307::getTimeStr(uint8_t format)
 
 char *DS1307::getDateStr(uint8_t slformat, uint8_t eformat, char divider)
 {
-	char *output= "xxxxxxxxxx";
+	char *output= (char*)"xxxxxxxxxx";
 	int yr, offset;
 	Time t;
 	t=getTime();
@@ -245,31 +245,31 @@ char *DS1307::getDateStr(uint8_t slformat, uint8_t eformat, char divider)
 
 char *DS1307::getDOWStr(uint8_t format)
 {
-	char *output= "xxxxxxxxx";
+	char *output= (char*)"xxxxxxxxx";
 	Time t;
 	t=getTime();
 	switch (t.dow)
 	{
 		case MONDAY:
-			output="Monday";
+			output=(char*)"Monday";
 			break;
 		case TUESDAY:
-			output="Tuesday";
+			output=(char*)"Tuesday";
 			break;
 		case WEDNESDAY:
-			output="Wednesday";
+			output=(char*)"Wednesday";
 			break;
 		case THURSDAY:
-			output="Thursday";
+			output=(char*)"Thursday";
 			break;
 		case FRIDAY:
-			output="Friday";
+			output=(char*)"Friday";
 			break;
 		case SATURDAY:
-			output="Saturday";
+			output=(char*)"Saturday";
 			break;
 		case SUNDAY:
-			output="Sunday";
+			output=(char*)"Sunday";
 			break;
 	}     
 	if (format==FORMAT_SHORT)
@@ -279,46 +279,46 @@ char *DS1307::getDOWStr(uint8_t format)
 
 char *DS1307::getMonthStr(uint8_t format)
 {
-	char *output= "xxxxxxxxx";
+	char *output= (char*)"xxxxxxxxx";
 	Time t;
 	t=getTime();
 	switch (t.mon)
 	{
 		case 1:
-			output="January";
+			output=(char*)"January";
 			break;
 		case 2:
-			output="February";
+			output=(char*)"February";
 			break;
 		case 3:
-			output="March";
+			output=(char*)"March";
 			break;
 		case 4:
-			output="April";
+			output=(char*)"April";
 			break;
 		case 5:
-			output="May";
+			output=(char*)"May";
 			break;
 		case 6:
-			output="June";
+			output=(char*)"June";
 			break;
 		case 7:
-			output="July";
+			output=(char*)"July";
 			break;
 		case 8:
-			output="August";
+			output=(char*)"August";
 			break;
 		case 9:
-			output="September";
+			output=(char*)"September";
 			break;
 		case 10:
-			output="October";
+			output=(char*)"October";
 			break;
 		case 11:
-			output="November";
+			output=(char*)"November";
 			break;
 		case 12:
-			output="December";
+			output=(char*)"December";
 			break;
 	}     
 	if (format==FORMAT_SHORT)
@@ -587,3 +587,4 @@ uint8_t DS1307::peek(uint8_t addr)
 	else
 		return 0;
 }
+

--- a/Documentation/version.txt
+++ b/Documentation/version.txt
@@ -1,4 +1,5 @@
 Version:
 	1.0	 4 Oct 2010  -  initial release
 	1.1	26 Jan 2012  -  Added support for Arduino 1.0 IDE
+	1.1.1.  07 Apr 2019  -  Adjusted C++11 warnings from string to constant char* casting
 	


### PR DESCRIPTION
Adjusted some (char*) casting so it wouldn't get any warning like this:

>>> In member function 'char* DS1307::getMonthStr(uint8_t)':
>>> warning: ISO C++ forbids converting a string constant to 'char*' [-Wwrite-strings] output="December";
          ^